### PR TITLE
Fix leaked GBlock in the guest

### DIFF
--- a/src/block_manager.rs
+++ b/src/block_manager.rs
@@ -574,6 +574,7 @@ impl BMInner {
                     self.v_prep(fix, guest_ptr, validator)?;
 
                     let data = fix.vm.mem.free(gb.data)?;
+                    fix.vm.mem.free(guest_ptr)?;
                     self.locks.insert(
                         gb.loc,
                         Lock::Clean {


### PR DESCRIPTION
Fixed one of the two memleak issues found. There's still another leakage issue in `Fixture::alloc_ebreak`. Should be fixed later.